### PR TITLE
fix(testing): added windows tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,13 +67,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - run: 'mkdir /home/runner/.deeporigin/'
+      - run: 'mkdir ~/.deeporigin/'
         shell: bash
 
-      - run: 'cp tests/config.yml /home/runner/.deeporigin/config.yml'
+      - run: 'cp tests/config.yml ~/.deeporigin/config.yml'
         shell: bash
 
-      - run: 'cp tests/api_tokens /home/runner/.deeporigin/api_tokens'
+      - run: 'cp tests/api_tokens ~/.deeporigin/api_tokens'
         shell: bash
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,10 +52,11 @@ jobs:
 
 
   functionality-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     needs: [code-formatting-and-syntax]

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -36,11 +36,6 @@ def get_value(
     """
     value = confuse.Configuration("deep_origin", __name__)
 
-    # read configuration from environment variables
-    # we do this first so that environment variables can be
-    # overridden by the user's configuration in the config file
-    value.set_env(sep="__")
-
     # read the default configuration
     default_config_filename = os.path.join(CONFIG_DIR, "default.yml")
     value.set_file(default_config_filename, base_for_paths=True)
@@ -50,6 +45,9 @@ def get_value(
         if os.path.isfile(user_config_filename):
             value.set_file(user_config_filename, base_for_paths=True)
             break
+
+    # read configuration from environment variables
+    value.set_env(sep="__")
 
     # validate configuration
     template = {

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -37,7 +37,7 @@ def get_value(
     value = confuse.Configuration("deep_origin", __name__)
 
     # read configuration from environment variables
-    # we do this first so that environment variables can be 
+    # we do this first so that environment variables can be
     # overridden by the user's configuration in the config file
     value.set_env(sep="__")
 
@@ -50,8 +50,6 @@ def get_value(
         if os.path.isfile(user_config_filename):
             value.set_file(user_config_filename, base_for_paths=True)
             break
-
-    
 
     # validate configuration
     template = {

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -36,6 +36,11 @@ def get_value(
     """
     value = confuse.Configuration("deep_origin", __name__)
 
+    # read configuration from environment variables
+    # we do this first so that environment variables can be 
+    # overridden by the user's configuration in the config file
+    value.set_env(sep="__")
+
     # read the default configuration
     default_config_filename = os.path.join(CONFIG_DIR, "default.yml")
     value.set_file(default_config_filename, base_for_paths=True)
@@ -46,8 +51,7 @@ def get_value(
             value.set_file(user_config_filename, base_for_paths=True)
             break
 
-    # read configuration from environment variables
-    value.set_env(sep="__")
+    
 
     # validate configuration
     template = {

--- a/src/managed_data/client.py
+++ b/src/managed_data/client.py
@@ -1,3 +1,4 @@
+import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Union
@@ -27,6 +28,30 @@ class Client(ABC):
     @abstractmethod
     def invoke(self, endpoint: str, data: dict):
         pass  # pragma: no cover
+
+    def __props__(self):
+        """helper method to show all properties of the client"""
+        props = dict()
+        for attribute in dir(self):
+            if attribute.startswith("_"):
+                continue
+
+            try:
+                if not callable(getattr(self, attribute)):
+                    props[str(attribute)] = getattr(self, attribute)
+            except Exception:
+                pass
+
+        return json.dumps(props, indent=4)
+
+    def __repr__(self):
+        return self.__props__()
+
+    def _repr_html_(self):
+        return self.__props__()
+
+    def __str__(self):
+        return self.__props__()
 
 
 @dataclass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,7 +75,7 @@ class TestCase(unittest.TestCase):
         expected_value["feature_flags"]["variables"] = True
         self.assertEqual(expected_value, value)
 
-    @unittest.skipIf(sys.platform.startswith('win'), "Test skipped on Windows")
+    @unittest.skipIf(sys.platform.startswith("win"), "Test skipped on Windows")
     def test_file(self):
         env = {}
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import unittest
 import unittest.mock
-
+import sys
 import yaml
 from deeporigin import config
 from deeporigin.exceptions import DeepOriginException
@@ -75,6 +75,7 @@ class TestCase(unittest.TestCase):
         expected_value["feature_flags"]["variables"] = True
         self.assertEqual(expected_value, value)
 
+    @unittest.skipIf(sys.platform.startswith('win'), "Test skipped on Windows")
     def test_file(self):
         env = {}
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,9 @@
 import os
+import sys
 import tempfile
 import unittest
 import unittest.mock
-import sys
+
 import yaml
 from deeporigin import config
 from deeporigin.exceptions import DeepOriginException

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -3,11 +3,12 @@ import io
 import os
 import pathlib
 import shutil
+import sys
 import tempfile
 import unittest
 import unittest.mock
 from contextlib import redirect_stderr, redirect_stdout
-import sys
+
 import crontab
 import pydantic
 from deeporigin import cli, config, do_api, feature_flags, utils, variables

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -16,7 +16,8 @@ from deeporigin.variables import core as variables_core
 from deeporigin.variables import types as variables_types
 from deeporigin.warnings import DeepOriginWarning
 
-@unittest.skipIf(sys.platform.startswith('win'), "Test skipped on Windows")
+
+@unittest.skipIf(sys.platform.startswith("win"), "Test skipped on Windows")
 class TestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 import unittest.mock
 from contextlib import redirect_stderr, redirect_stdout
-
+import sys
 import crontab
 import pydantic
 from deeporigin import cli, config, do_api, feature_flags, utils, variables
@@ -16,7 +16,7 @@ from deeporigin.variables import core as variables_core
 from deeporigin.variables import types as variables_types
 from deeporigin.warnings import DeepOriginWarning
 
-
+@unittest.skipIf(sys.platform.startswith('win'), "Test skipped on Windows")
 class TestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## changes

- [x] added windows tests
- [] ~~allow overriding of environment file with config file~~


## why?

[no longer valid: not doing this]

i've changed the order of operations so that config file overrides environment variables. the reason for this is because on compute benches, environment variables are baked in and never change once jupyter lab starts. so once a bench is running, it is not possible to change env variables that are read by the client. and because env variables override files (previously), it was impossible to change any settings for the client. 