### PR TITLE
fix(CLI): fixed a bug where `deep-origin` was still being used

### DIFF
--- a/src/variables/core.py
+++ b/src/variables/core.py
@@ -376,9 +376,6 @@ def enable_variable_auto_updating(
         warnings.warn(msg, FeatureNotAvailableWarning)
         return []
 
-    # Get an access token for the Deep Origin API
-    tokens = auth.get_tokens()
-
     # load the CronTab configuration
     with crontab.CronTab(user=True) as cron_tab:
         # get the id of the cron job
@@ -462,7 +459,7 @@ def enable_variable_auto_updating(
 
         if not cli:
             cli = sys.argv[0]
-            if not cli.endswith("/deep-origin") and not cli.endswith(
+            if not cli.endswith("/deeporigin") and not cli.endswith(
                 "pytest/__main__.py"
             ):
                 raise DeepOriginException(
@@ -484,7 +481,7 @@ def enable_variable_auto_updating(
             cli_command.append("--overwrite")
 
         log_filename = os.path.expanduser(
-            os.path.join("~", ".log", "deep-origin", "variables-auto-install.log")
+            os.path.join("~", ".log", "deeporigin", "variables-auto-install.log")
         )
         os.makedirs(os.path.dirname(log_filename), exist_ok=True)
 

--- a/src/variables/types/env_var.py
+++ b/src/variables/types/env_var.py
@@ -269,8 +269,8 @@ class EnvironmentVariable(Variable):
             :obj:`str`: Environment variable filename
         """
         if is_user_variable:
-            return os.path.join(user_home_dirname, ".deep-origin", "user-variables.env")
+            return os.path.join(user_home_dirname, ".deeporigin", "user-variables.env")
         else:
             return os.path.join(
-                user_home_dirname, ".deep-origin", "system-variables.env"
+                user_home_dirname, ".deeporigin", "system-variables.env"
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,18 +16,18 @@ class TestCase(unittest.TestCase):
         with unittest.mock.patch("sys.argv", ["", "--help"]):
             with self.assertRaises(SystemExit) as context:
                 cli.main()
-                self.assertRegex(context.Exception, "usage: deep-origin")
+                self.assertRegex(context.Exception, "usage: deeporigin")
 
     def test_help(self):
         with cli.App(argv=["--help"]) as app:
             with self.assertRaises(SystemExit) as context:
                 app.run()
-                self.assertRegex(context.Exception, "usage: deep-origin")
+                self.assertRegex(context.Exception, "usage: deeporigin")
 
         with cli.App(argv=[]) as app:
             with self.assertRaises(SystemExit) as context:
                 app.run()
-                self.assertRegex(context.Exception, "usage: deep-origin")
+                self.assertRegex(context.Exception, "usage: deeporigin")
 
     def test_version(self):
         stdout_capture = io.StringIO()

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -1630,7 +1630,7 @@ class TestCase(unittest.TestCase):
         ]
         with unittest.mock.patch("requests.post", side_effect=responses):
             variables.enable_variable_auto_updating(
-                user=False, org=False, cli="deep-origin"
+                user=False, org=False, cli="deeporigin"
             )
 
         with crontab.CronTab(user=True) as cron_tab:
@@ -2482,7 +2482,7 @@ class TestCase(unittest.TestCase):
         var_xpress.install(None, user_home_dirname)
         expected_filenames.append(var_xpress.FILENAME.replace("~/", ""))
         expected_filenames.append(".bashrc")
-        expected_filenames.append(".deep-origin")
+        expected_filenames.append(".deeporigin")
         self.assertEqual(
             sorted(expected_filenames), sorted(os.listdir(user_home_dirname))
         )


### PR DESCRIPTION
## changes

as part of the renaming of this CLI, from deep-origin to deeporigin, we forgot to change where variables were being stored. this has now been fixed. 